### PR TITLE
Discounts destroy

### DIFF
--- a/app/controllers/merchant/discounts_controller.rb
+++ b/app/controllers/merchant/discounts_controller.rb
@@ -26,6 +26,12 @@ class Merchant::DiscountsController < Merchant::BaseController
     end
   end
 
+  def destroy
+    discount = Discount.find(params[:id]).destroy
+    flash[:notice] = "#{discount.name} has been removed from discounts."
+    redirect_to merchant_discounts_path
+  end
+
   private
 
   def discount_params

--- a/app/models/discount.rb
+++ b/app/models/discount.rb
@@ -11,5 +11,5 @@ class Discount < ApplicationRecord
                           :discount_amt
 
   validates_inclusion_of :discount_amt, in: 0.001..0.99, message: "Discount must be between 0.001 and .99"
-  validates_inclusion_of :req_qty, in: 0..999, message: "Discount must be between 0.001 and .99"
+  validates_inclusion_of :req_qty, in: 0..999, message: "Discount must be between 0 and 999"
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -3,7 +3,7 @@ class Merchant < ApplicationRecord
   has_many :order_items, through: :items
   has_many :orders, through: :order_items
   has_many :users
-  has_many :discounts
+  has_many :discounts, dependent: :destroy
 
   validates_presence_of :name,
                         :address,

--- a/app/views/merchant/discounts/index.html.erb
+++ b/app/views/merchant/discounts/index.html.erb
@@ -2,7 +2,8 @@
 
 <% @discounts.each do |discount| %>
   <section id="discount-<%= discount.id %>">
-    <%= link_to discount.name, "/merchant/discounts/#{discount.id}" %></br></br>
+    <h2><%= link_to discount.name, "/merchant/discounts/#{discount.id}" %></h2>
+    <%= link_to "Delete Discount", "/merchant/discounts/#{discount.id}", method: :delete %></br></br>
   </section>
 <% end %></br></br>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
     get '/', to: 'dashboard#index', as: :dashboard
     resources :orders, only: :show
     resources :items, only: [:index, :new, :create, :edit, :update, :destroy]
-    resources :discounts, only: [:index, :show, :new, :create, :post]
+    resources :discounts, only: [:index, :show, :new, :create, :post, :destroy]
     put '/items/:id/change_status', to: 'items#change_status'
     get '/orders/:id/fulfill/:order_item_id', to: 'orders#fulfill'
   end

--- a/spec/features/discounts/destroy_spec.rb
+++ b/spec/features/discounts/destroy_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe "Discount Destroy Spec", type: :feature do 
+  describe "- when I visit the discounts index page and click delete on a discount" do
+    it "then it is removed from the index page." do 
+      merchant_1 = Merchant.create!(name: 'Megans Marmalades', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218)
+      
+      m_user = merchant_1.users.create!(name: 'Megan', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218, role: 1, email: 'merchant_megan@example.com', password: 'password')
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(m_user)
+
+      five_percent = merchant_1.discounts.create!(name: "5% Discount", description: "This discount applies once item quantity reaches 5 and remains until quantity reaches 10.", discount_amt: 0.05, req_qty: 5)
+      ten_percent = merchant_1.discounts.create!(name: "10% Discount", description: "This discount applies once item quantity reaches 10 and remains until quantity reaches 15.", discount_amt: 0.1, req_qty: 5)
+
+      visit merchant_discounts_path 
+
+      expect(page).to have_link("10% Discount")
+
+      within "#discount-#{ten_percent.id}" do
+        click_link "Delete Discount"
+      end 
+      
+      expect(current_path).to eq(merchant_discounts_path)
+      expect(page).to have_content("10% Discount has been removed from discounts.")
+    end 
+  end 
+end 


### PR DESCRIPTION
Made the following changes:
 - created test to check for discount deletion
 - updated routes to include path for destroying a discount
 - updated index page to include a delete option within each section that contains a discount
 - added destroy method to discounts controller 
 - added dependent destroy clause so discounts are deleted when a merchant is deleted
 - updated error message when a required quantity is entered that is not between 0 and 999